### PR TITLE
Bugfix Taxi light switch

### DIFF
--- a/xsaitekpanels.ini
+++ b/xsaitekpanels.ini
@@ -5,7 +5,7 @@
 ;William R Good
 ;Source: https://github.com/daniol/xsaitekpanels-zibo
 ;
-Version = 1.13
+Version = 1.14
 ;
 ;Custom map for Zibo Boeing 737-800
 ;
@@ -2401,22 +2401,22 @@ taxi_lights_switch_on_cmd = laminar/B738/toggle_switch/taxi_light_brightness_pos
 taxi_lights_switch_off_cmd = laminar/B738/toggle_switch/taxi_light_brightness_pos_up
 
 ;command for taxi light switch on command2
-taxi_lights_switch2_on_cmd = FlyWithLua/AceXSP/Switch_Taxi_On
+taxi_lights_switch2_on_cmd = laminar/B738/toggle_switch/taxi_light_brightness_pos_dn
 
 ;command for taxi light switch off command2
-taxi_lights_switch2_off_cmd = laminar/B738/switch/rwy_light_left_off
+taxi_lights_switch2_off_cmd = laminar/B738/toggle_switch/taxi_light_brightness_pos_up
 
 ;command for taxi light switch on command3
-taxi_lights_switch3_on_cmd = 
+taxi_lights_switch3_on_cmd = FlyWithLua/AceXSP/Switch_Taxi_On
 
 ;command for taxi light switch off command3
-taxi_lights_switch3_off_cmd = laminar/B738/switch/rwy_light_right_off
+taxi_lights_switch3_off_cmd = laminar/B738/switch/rwy_light_left_off
 
 ;command for taxi light switch on command4
 taxi_lights_switch4_on_cmd =
 
 ;command for taxi light switch off command4
-taxi_lights_switch4_off_cmd = 
+taxi_lights_switch4_off_cmd = laminar/B738/switch/rwy_light_right_off
 
 ;command for taxi light switch on command5
 taxi_lights_switch5_on_cmd =


### PR DESCRIPTION
Fixes #9.
It seems that Zibo changed the behavior of the taxi switch and introduced an intermediate position between on and off (?).
So it is necessary to call two times the command "taxi_light_brightness_pos_dn" to turn the lights on and two times "taxi_light_brightness_pos_up" to turn them off.

Tested with Zibo 3.45.15